### PR TITLE
Allow named polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Change Log
+All user visible changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/), as described
+for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md)
+
+## Unreleased
+
+### Changed
+
+* `setup` now takes an object with the properties `name`, `resource_name`, `url` and `params`
+  instead of the three params `resource_name`, `url` and `params`.
+  For example;
+  ```javascript
+  this.get('poll').setup('contacts', 'http://some_domain.com/contacts/${contact_id}');
+  ```
+  becomes;
+  ```javascript
+  this.get('poll').setup({
+    name: 'contactsPoll',
+    resource_name: 'contacts',
+    url: 'http://some_domain.com/contacts/${contact_id}'
+  });
+  ```

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ var ExampleRoute = Ember.Route.extend({
   ...
   afterModel: function (model, transition) {
     this.get('poll').setup({
-      pollName: 'myContactsPoll', // poll name should be unique
-      resourceName: 'contacts', // a resource name
-      url: `http://some_domain.com/contacts/${contactId}` // url to fetch resource
+      name: 'contactsPoll', // a poll name should be unique
+      resource_name: 'contacts', // a resource name
+      url: `http://some_domain.com/contacts/${contact_id}` // url to fetch resource
     });
   },
   actions: {
     willTransition: function (transition) {
       this._super(transition);
-      this.get('poll').removePoll('myContactsPoll'); // remove from polling
+      this.get('poll').removePoll('contactsPoll'); // remove the resource from polling
     },
   }
   ...
@@ -73,15 +73,15 @@ var SomeComponent = Ember.component.extend({
       other_param: 'other_value'
     };
     this.get('poll').setup({
-      pollName: 'usersPoll',
-      resourceName: 'users', // resource name
+      name: 'usersPoll', // a poll name should be unique
+      resource_name: 'users', // resource name
       url: `http://some_domain.com/users`, // url to fetch resource
       params: query_params // query params
     });
   },
   willDestroy: function () {
     this._super();
-    this.get('poll').removePoll('usersPoll'); // remove from polling
+    this.get('poll').removePoll('usersPoll'); // remove resource from polling
   }
 });
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  ember-cli-poll
 
-This is an npm package that contains a polling serivce for ember-data
+This is a fork of an npm package that contains a polling serivce for ember-data
 packaged as an [Ember CLI](https://github.com/stefanpenner/ember-cli) Addon.
 
 ## Installation
@@ -8,7 +8,7 @@ packaged as an [Ember CLI](https://github.com/stefanpenner/ember-cli) Addon.
 To install simply run
 
 ```
-ember install ember-cli-poll
+ember install https://github.com/Biteable/ember-cli-poll.git
 ```
 
 in your Ember CLI project's root.
@@ -26,7 +26,7 @@ var ApplicationRoute = Ember.Route.extend({
   afterModel: function () {
     this._super(...arguments);
     this.get('poll').start({
-      idle_timeout: 10000,
+      idleTimeout: 10000,
       interval: 2000,
     });
   }
@@ -45,15 +45,16 @@ var ExampleRoute = Ember.Route.extend({
   poll: Ember.inject.service(),
   ...
   afterModel: function (model, transition) {
-    this.get('poll').setup(
-      'contacts', // a resource name
-      `http://some_domain.com/contacts/${contact_id}` // url to fetch resource
-    );
+    this.get('poll').setup({
+      pollName: 'myContactsPoll', // poll name should be unique
+      resourceName: 'contacts', // a resource name
+      url: `http://some_domain.com/contacts/${contactId}` // url to fetch resource
+    });
   },
   actions: {
     willTransition: function (transition) {
       this._super(transition);
-      this.get('poll').removePoll('contacts'); // remove the resource from polling
+      this.get('poll').removePoll('myContactsPoll'); // remove from polling
     },
   }
   ...
@@ -71,15 +72,16 @@ var SomeComponent = Ember.component.extend({
       some_param: 'some_value',
       other_param: 'other_value'
     };
-    this.get('poll').setup(
-      'users', // resource name
-      `http://some_domain.com/users`, // url to fetch resource
-      query_params // query params
-    );
+    this.get('poll').setup({
+      pollName: 'usersPoll',
+      resourceName: 'users', // resource name
+      url: `http://some_domain.com/users`, // url to fetch resource
+      params: query_params // query params
+    });
   },
   willDestroy: function () {
     this._super();
-    this.get('poll').removePoll('users'); // remove resource from polling
+    this.get('poll').removePoll('usersPoll'); // remove from polling
   }
 });
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  ember-cli-poll
 
-This is a fork of an npm package that contains a polling serivce for ember-data
+This is an npm package that contains a polling serivce for ember-data
 packaged as an [Ember CLI](https://github.com/stefanpenner/ember-cli) Addon.
 
 ## Installation
@@ -8,7 +8,7 @@ packaged as an [Ember CLI](https://github.com/stefanpenner/ember-cli) Addon.
 To install simply run
 
 ```
-ember install https://github.com/Biteable/ember-cli-poll.git
+ember install ember-cli-poll
 ```
 
 in your Ember CLI project's root.
@@ -26,7 +26,7 @@ var ApplicationRoute = Ember.Route.extend({
   afterModel: function () {
     this._super(...arguments);
     this.get('poll').start({
-      idleTimeout: 10000,
+      idle_timeout: 10000,
       interval: 2000,
     });
   }


### PR DESCRIPTION
This PR introduces the ability to name polls.  This affords multiple polls against the same resource for example `GET /conversations` can be polled less frequently than `GET /conversations/99`

@mfpiccolo this is my first contribution to an individual's project.  Please feel free to tell me what you want me to do to make the merge as easy possible for you.
